### PR TITLE
Fix go vet problem with lock value copying

### DIFF
--- a/mox/callmock.go
+++ b/mox/callmock.go
@@ -1,5 +1,3 @@
-// +build small medium large
-
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #11 
Summary of changes:
- Replaced direct locks with pointer to mutex, so copying object copies just pointer to mutex

How to verify it:
- Run `TEST_TYPE=small UNIT_TEST="gofmt goimports go_test go_vet" make test`, there will be no go vet errors now and unit tests are passing

Testing done:
- Unit tests

